### PR TITLE
Add default value for asp_group

### DIFF
--- a/examples/ibmi/playbooks/ibmi-cl-command-sample.yml
+++ b/examples/ibmi/playbooks/ibmi-cl-command-sample.yml
@@ -7,6 +7,7 @@
   - name: run the CL command to create a library
     ibmi_cl_command:
       cmd: crtlib lib(ansiblei)
+      asp_group: ''
     register: crt_lib_result
     ignore_errors: True
 


### PR DESCRIPTION
This fails to run in my test without a valid ASP device specified for asp_group.   I added asp_group: '' which is the default value and should create the file in the system ASP by default.