### PR TITLE
Changing pip install to pip3 install

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -44,7 +44,7 @@ In order to use this Ansible collection, you must have the following pre-requisi
 
     ::
 
-        pip install ansible
+        pip3 install ansible
 
 Installing using Ansible Galaxy
 -------------------------------


### PR DESCRIPTION
`pip install ansible ` gives error when ran from ssh shell
changed to `pip3 install ansible` 