### PR TITLE
changed include to include_tasks

### DIFF
--- a/roles/apply_ptf/tasks/main.yml
+++ b/roles/apply_ptf/tasks/main.yml
@@ -6,7 +6,7 @@
     apply_fail_dict: {}
     apply_fail_with_requisite_list: []
 
-- include: apply_all_loaded_ptfs.yml
+- include_tasks: apply_all_loaded_ptfs.yml
   when: apply_all_loaded_ptfs
 
 - block:


### PR DESCRIPTION
"include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16.