### PR TITLE
Changed ALL_GROUP_PAGE to the updated URL

### DIFF
--- a/plugins/modules/ibmi_fix_check.py
+++ b/plugins/modules/ibmi_fix_check.py
@@ -133,10 +133,10 @@ import re
 __ibmi_module_version__ = "1.9.1"
 
 PSP_URL = "https://www.ibm.com/support/pages/sites/default/files/inline-files/xmldoc.xml"
-ALL_GROUP_PAGE = "https://www.ibm.com/support/pages/node/6211843"
+ALL_GROUP_PAGE = "https://www.ibm.com/support/pages/ibm-i-group-ptfs-level"
 
 
-# url: https://www.ibm.com/support/pages/node/6211843
+# url: https://www.ibm.com/support/pages/ibm-i-group-ptfs-level
 # group: 'SF99738'
 def get_group_info_from_web(groups, certs, timeout):
     pattern_link = re.compile(

--- a/plugins/modules/ibmi_fix_group_check.py
+++ b/plugins/modules/ibmi_fix_group_check.py
@@ -106,10 +106,10 @@ import re
 __ibmi_module_version__ = "1.9.1"
 
 PSP_URL = "https://www.ibm.com/support/pages/sites/default/files/inline-files/xmldoc.xml"
-ALL_GROUP_PAGE = "https://www.ibm.com/support/pages/node/6211843"
+ALL_GROUP_PAGE = "https://www.ibm.com/support/pages/ibm-i-group-ptfs-level"
 
 
-# url: https://www.ibm.com/support/pages/node/6211843
+# url: https://www.ibm.com/support/pages/ibm-i-group-ptfs-level
 # group: 'SF99738'
 def get_group_info_from_web(groups, validate_certs, timeout):
     pattern_link = re.compile(

--- a/tests/integration/targets/ibmi_fix_repo/tasks/main.yml
+++ b/tests/integration/targets/ibmi_fix_repo/tasks/main.yml
@@ -14,7 +14,7 @@
   - debug:
       msg: "{{os400_ver}}"  
   - set_fact:  # pre-define some ptfs/groups for each os version to test
-               # IBM i Group PTFs with level --> https://www.ibm.com/support/pages/node/6211843
+               # IBM i Group PTFs with level --> https://www.ibm.com/support/pages/ibm-i-group-ptfs-level
       ptfs: ['SI69340', 'SI71891', 'SI69764']
       ptf_grps: ['SF99667']  # group 1, group 2( with different levels) , group 3 - cum
     when: os400_ver == "V7R4M0"


### PR DESCRIPTION
Created PR to fix this issue:
https://github.com/IBM/ansible-for-i/issues/157

Changed `ALL_GROUP_PAGE`  URL from https://www.ibm.com/support/pages/node/6211843 to https://www.ibm.com/support/pages/ibm-i-group-ptfs-level