### PR TITLE
Missing filter pattern + use the same hostgroup as example

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -47,5 +47,5 @@ Refer to Ansible community doc to learn how to run Ansible command or playbook h
 Examples:
 ::
 
-    ansible -i inventory.ini -m ibm.power_ibmi.ibmi_cl_command -a "cmd='crtlib lib(demo111)'"
-    ansible -i inventory.ini db2mb1pa -m ibm.power_ibmi.ibmi_reboot
+    ansible -i inventory.ini ibmi -m ibm.power_ibmi.ibmi_cl_command -a "cmd='crtlib lib(demo111)'"
+    ansible -i inventory.ini ibmi -m ibm.power_ibmi.ibmi_reboot


### PR DESCRIPTION
Hi,

With the first line of this example, it's missed the pattern, or you will have this error with Ansible CLI:
`ansible: error: the following arguments are required: pattern`

Moreover, I suggest renaming **db2mb1pa** in the second example to **ibmi**, to be consistent with the hostgroup name in the previous example on this documentation page.

Kind regards