### PR TITLE
Added is_cmd5250 parameter to ibmi_cl_command.py

### DIFF
--- a/plugins/modules/ibmi_cl_command.py
+++ b/plugins/modules/ibmi_cl_command.py
@@ -35,6 +35,10 @@ options:
       - Ignored when the CL command with OUTPUT parameter, e.g. DSPLIBL, DSPHDWRSC.
     type: str
     default: '*SYSBAS'
+  is_cmd5250:
+    description:
+      - Specifies if the the command is expected to display output.
+      - Explicitly runs the command using run_command module instead of itoolkit_run_command_once module.
   joblog:
     description:
       - If set to C(true), output the available job log even the rc is 0(success).
@@ -69,6 +73,10 @@ EXAMPLES = r'''
     cmd: 'CRTLIB LIB(TESTLIB)'
     become_user: 'USER1'
     become_user_password: 'yourpassword'
+- name: Run Check Product Option (CHKPRDOPT) command to verify that licensed programs are fully installed.
+  ibm.power_ibmi.ibmi_cl_command:
+    cmd: 'CHKPRDOPT *OPSYS'
+    is_cmd5250: True
 '''
 
 RETURN = r'''
@@ -172,6 +180,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             cmd=dict(type='str', required=True),
+            is_cmd5250=dict(type='bool', default=False),
             asp_group=dict(type='str', default='*SYSBAS'),
             joblog=dict(type='bool', default=False),
             become_user=dict(type='str'),
@@ -183,6 +192,7 @@ def main():
     ibmi_util.log_info("version: " + __ibmi_module_version__, module._name)
 
     command = module.params['cmd'].strip()
+    is_cmd5250 = module.params['is_cmd5250']
     asp_group = module.params['asp_group'].strip().upper()
     joblog = module.params['joblog']
     become_user = module.params['become_user']
@@ -191,7 +201,6 @@ def main():
     startd = datetime.datetime.now()
 
     command_upper = command.upper()
-    is_cmd5250 = False
     if command_upper.startswith('DSP'):
         is_cmd5250 = True
     if command_upper.startswith('QSYS/DSP'):


### PR DESCRIPTION
Referring to issue https://github.com/IBM/ansible-for-i/issues/165

Added `is_cmd5250` parameter to `ibmi_cl_command.py` to explicitly run the command using the `run_command` module instead of `itoolkit_run_command_once` module.