### PR TITLE
Update main.yml for fix_repo_download_apply_individual_ptfs

### DIFF
--- a/roles/fix_repo_download_apply_individual_ptfs/tasks/main.yml
+++ b/roles/fix_repo_download_apply_individual_ptfs/tasks/main.yml
@@ -244,6 +244,3 @@
       ansible.builtin.debug:
         var: fix_repo_download_apply_individual_ptfs_requisite_ptfs_status
       when: fix_repo_download_apply_individual_ptfs_requisite_ptfs_status is defined
-
-    - name: End host (end_host)
-      ansible.builtin.meta: end_host


### PR DESCRIPTION
Remove meta host as it creates a problem when integrated with other playbooks.

    - name: End host (end_host)
      ansible.builtin.meta: end_host

Issue : #209